### PR TITLE
Clean up global variables and download()

### DIFF
--- a/pyiwn/pyiwn.py
+++ b/pyiwn/pyiwn.py
@@ -17,7 +17,7 @@ languages = ['assamese', 'bengali', 'bodo', 'english', 'gujarati', 'hindi',
 
 USER_HOME = str(Path.home())
 IWN_URL = "https://www.dropbox.com/s/a3tlr5ll3y3pef6/pyiwn_data.zip?dl=1"
-home = user_home + '/pyiwn_data'
+home = USER_HOME + '/pyiwn_data'
 
 def langs():
     return 'pyiwn supports the WordNets of the following languages: {}'.format(str(languages))

--- a/pyiwn/pyiwn.py
+++ b/pyiwn/pyiwn.py
@@ -15,22 +15,28 @@ languages = ['assamese', 'bengali', 'bodo', 'english', 'gujarati', 'hindi',
              'kannada', 'kashmiri', 'konkani', 'malayalam', 'marathi', 'meitei', 
              'nepali', 'oriya', 'punjabi', 'sanskrit', 'tamil', 'telugu', 'urdu']
 
-user_home = str(Path.home())
+USER_HOME = str(Path.home())
+IWN_URL = "https://www.dropbox.com/s/a3tlr5ll3y3pef6/pyiwn_data.zip?dl=1"
 home = user_home + '/pyiwn_data'
-iwn_url = "https://www.dropbox.com/s/a3tlr5ll3y3pef6/pyiwn_data.zip?dl=1"
 
 def langs():
     return 'pyiwn supports the WordNets of the following languages: {}'.format(str(languages))
                 
-def download():
+def download(path=USER_HOME, url=IWN_URL):
+    """ Downloads the Indian WordNet. 
+    :param path: Path to save the Indian WordNet.
+    :type path: str
+    :param url: Url to download the IWN zipfile.
+    :type url: str
+    """
     print('Please wait. Downloading IndoWordnet synset data (80 MB) to {}'.format(user_home), file=sys.stderr)
     pyiwn_data_path = '{}/pyiwn_data.zip'.format(user_home)
-    with urllib.request.urlopen(iwn_url) as response:
+    with urllib.request.urlopen(url) as response:
         with open(pyiwn_data_path, 'wb') as out_file:
             shutil.copyfileobj(response, out_file)
     print('Extracting pyiwn data...', file=sys.stderr)
     with zipfile.ZipFile(pyiwn_data_path, 'r') as zip_ref:
-        zip_ref.extractall(user_home)
+        zip_ref.extractall(path)
     os.remove(pyiwn_data_path)
     print('Download successful.', file=sys.stderr)
 

--- a/pyiwn/pyiwn.py
+++ b/pyiwn/pyiwn.py
@@ -1,32 +1,38 @@
+from __future__ import print_function
+
 from pyiwn import utils
 from pathlib import Path
 import urllib.request
 import shutil
 import zipfile
 import os
+import sys
 
 
 NOUN, VERB, ADVERB, ADJECTIVE = 'noun', 'verb', 'adverb', 'adjective'
 
-languages = ['hindi', 'english', 'assamese', 'bengali', 'bodo', 'gujarati', 'kannada', 'kashmiri', 'konkani', 'malayalam', 'meitei', 'marathi', 'nepali', 'sanskrit', 'tamil', 'telugu', 'punjabi', 'urdu', 'oriya']
+languages = ['assamese', 'bengali', 'bodo', 'english', 'gujarati', 'hindi', 
+             'kannada', 'kashmiri', 'konkani', 'malayalam', 'marathi', 'meitei', 
+             'nepali', 'oriya', 'punjabi', 'sanskrit', 'tamil', 'telugu', 'urdu']
 
-home = str(Path.home()) + '/pyiwn_data'
+user_home = str(Path.home())
+home = user_home + '/pyiwn_data'
+iwn_url = "https://www.dropbox.com/s/a3tlr5ll3y3pef6/pyiwn_data.zip?dl=1"
 
 def langs():
     return 'pyiwn supports the WordNets of the following languages: {}'.format(str(languages))
                 
 def download():
-    url = "https://www.dropbox.com/s/a3tlr5ll3y3pef6/pyiwn_data.zip?dl=1"
-    pyiwn_data_path = '{}/pyiwn_data.zip'.format(str(Path.home()))
-    print('Please wait. Downloading IndoWordnet synset data (80 MB) to {}'.format(str(Path.home())))
-    with urllib.request.urlopen(url) as response, open(pyiwn_data_path, 'wb') as out_file:
-        shutil.copyfileobj(response, out_file)
-    print('Extracting pyiwn data...')
-    zip_ref = zipfile.ZipFile(pyiwn_data_path, 'r')
-    zip_ref.extractall(str(Path.home()))
-    zip_ref.close()
+    print('Please wait. Downloading IndoWordnet synset data (80 MB) to {}'.format(user_home), file=sys.stderr)
+    pyiwn_data_path = '{}/pyiwn_data.zip'.format(user_home)
+    with urllib.request.urlopen(iwn_url) as response:
+        with open(pyiwn_data_path, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+    print('Extracting pyiwn data...', file=sys.stderr)
+    with zipfile.ZipFile(pyiwn_data_path, 'r') as zip_ref:
+        zip_ref.extractall(user_home)
     os.remove(pyiwn_data_path)
-    print('Download successful.')
+    print('Download successful.', file=sys.stderr)
 
 
 class IndoWordNetError(Exception):

--- a/pyiwn/pyiwn.py
+++ b/pyiwn/pyiwn.py
@@ -29,8 +29,8 @@ def download(path=USER_HOME, url=IWN_URL):
     :param url: Url to download the IWN zipfile.
     :type url: str
     """
-    print('Please wait. Downloading IndoWordnet synset data (80 MB) to {}'.format(user_home), file=sys.stderr)
-    pyiwn_data_path = '{}/pyiwn_data.zip'.format(user_home)
+    print('Please wait. Downloading IndoWordnet synset data (80 MB) to {}'.format(path), file=sys.stderr)
+    pyiwn_data_path = '{}/pyiwn_data.zip'.format(path)
     with urllib.request.urlopen(url) as response:
         with open(pyiwn_data_path, 'wb') as out_file:
             shutil.copyfileobj(response, out_file)


### PR DESCRIPTION
 - Clean up global variables
 - Sorted languages alphabetically
 - Clean up (PEP8-ify) `download()`
 - Use context manager to handle ZipFile open/closing
 - Printing of logs going to stderr instead of stdout