### PR TITLE
Update iwn.py

### DIFF
--- a/pyiwn/iwn.py
+++ b/pyiwn/iwn.py
@@ -47,7 +47,7 @@ class IndoWordNet:
 
     def _load_synset_file(self, lang):
         filename = os.path.join(*[constants.IWN_DATA_PATH, 'synsets', 'all.{}'.format(lang)])
-        f = open(filename)
+        f = open(filename,encoding='utf-8')
         synsets = list(map(lambda line: self._load_synset(line), f.readlines()))
         synset_df = pd.DataFrame(synsets, columns=['synset_id', 'synsets', 'pos'])
         synset_df = synset_df.dropna()


### PR DESCRIPTION
I am install pyiwn via pip.iwn=pyiwn.IndoWordNet() comment give the ERROR:'charmap' codec can't decode byte 0x8d in position 13: character maps to <undefined>
We can solve this by adding
add the encoding="utf-8" to line 50 in iwn.py .(i.e)replaced by f = open(filename,encoding='utf-8')